### PR TITLE
add scss script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "This is the repository for the (in progress) landing page for the Canadian Undergraduate Computer Science Conference 2021. This README will document all required dependencies and instructions to run the repo on your local machine.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "scss": "node-sass --watch scss -o css"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
for some reason the command Napat listed to compile our sass files only works after I add this line to package.json’s scripts section, and i run npm run scss instead of her command directly. 